### PR TITLE
Material styling and better detail view

### DIFF
--- a/mock_server.js
+++ b/mock_server.js
@@ -3,7 +3,7 @@ const express = require('express');
 const app = express();
 const port = 3000;
 
-const data = require('./data/sample_spa_data.json');
+const data = require('./data/sample_spa_news.json');
 
 app.use(cors());
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1875,9 +1875,9 @@
       }
     },
     "@types/lodash": {
-      "version": "4.14.149",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
-      "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==",
+      "version": "4.14.150",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.150.tgz",
+      "integrity": "sha512-kMNLM5JBcasgYscD9x/Gvr6lTAv2NVgsKtet/hm93qMyf/D1pt+7jeEZklKJKxMVmXjxbRVQQGfqDSfipYCO6w==",
       "dev": true
     },
     "@types/minimatch": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@angular/language-service": "~7.0.0",
     "@types/jasmine": "~2.8.8",
     "@types/jasminewd2": "~2.0.3",
-    "@types/lodash": "^4.14.149",
+    "@types/lodash": "^4.14.150",
     "@types/node": "^10.17.18",
     "codelyzer": "^5.2.2",
     "cors": "^2.8.5",

--- a/projects/demo/src/app/app.component.html
+++ b/projects/demo/src/app/app.component.html
@@ -2,7 +2,7 @@
 
 <ngx-storyline-viewer
     serviceUrl="http://localhost:3000"
-    [views]="{'View1': {'people': ['A.J. Brown']}}"
+    [views]="{'Sample view': {'people': ['Bill McKibben']}}"
 >
     Loading...
 </ngx-storyline-viewer>

--- a/projects/storyline-viewer/ng-package.json
+++ b/projects/storyline-viewer/ng-package.json
@@ -4,7 +4,8 @@
   "lib": {
     "entryFile": "src/public-api.ts",
     "umdModuleIds": {
-      "ngx-infinite-scroll": "ngxInfiniteScroll"
+      "ngx-infinite-scroll": "ngxInfiniteScroll",
+      "lodash": "lodash"
     }
   }
 }

--- a/projects/storyline-viewer/package-lock.json
+++ b/projects/storyline-viewer/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "@cisl/ngx-storyline-viewer",
+  "version": "0.3.0",
+  "lockfileVersion": 1
+}

--- a/projects/storyline-viewer/package.json
+++ b/projects/storyline-viewer/package.json
@@ -8,6 +8,7 @@
     "@angular/core": "^9.0.0",
     "@angular/forms": "^9.0.0",
     "@angular/material": "^9.0.0",
-    "ngx-infinite-scroll": "^8.0.0"
+    "ngx-infinite-scroll": "^8.0.0",
+    "lodash": "^4.17.15"
   }
 }

--- a/projects/storyline-viewer/src/lib/drivers-sheet.component.html
+++ b/projects/storyline-viewer/src/lib/drivers-sheet.component.html
@@ -1,0 +1,3 @@
+<mat-chip-list>
+    <mat-chip *ngFor="let d of drivers" (click)="onDriverClick(d)">{{d | titlecase }}</mat-chip>
+</mat-chip-list>

--- a/projects/storyline-viewer/src/lib/drivers-sheet.component.ts
+++ b/projects/storyline-viewer/src/lib/drivers-sheet.component.ts
@@ -1,0 +1,15 @@
+import { Component, Inject } from '@angular/core';
+import { MAT_BOTTOM_SHEET_DATA, MatBottomSheetRef } from '@angular/material/bottom-sheet';
+
+@Component({
+    selector: 'driver-sheet',
+    templateUrl: 'drivers-sheet.component.html'
+})
+export class DriversSheet {
+
+    constructor(@Inject(MAT_BOTTOM_SHEET_DATA) public drivers: string[], private _bottomSheet: MatBottomSheetRef) {}
+
+    onDriverClick(d: string) {
+        this._bottomSheet.dismiss(d);
+    }
+}

--- a/projects/storyline-viewer/src/lib/remaining-concepts.pipe.ts
+++ b/projects/storyline-viewer/src/lib/remaining-concepts.pipe.ts
@@ -1,0 +1,12 @@
+import { Pipe, PipeTransform } from "@angular/core";
+
+@Pipe({
+    name: 'remainingConcepts'
+})
+export class RemainingConceptsPipe implements PipeTransform {
+    transform(value: string[], start?: number): string {
+        const startIndex = start || 5;
+        if(value.length <= startIndex) { return ''; }
+        else return '' + (value.length - startIndex) + ' others: ' + value.slice(startIndex).join(', ');
+    }
+}

--- a/projects/storyline-viewer/src/lib/sanitize-abstract.pipe.ts
+++ b/projects/storyline-viewer/src/lib/sanitize-abstract.pipe.ts
@@ -1,0 +1,13 @@
+import { Pipe, PipeTransform } from "@angular/core";
+
+@Pipe({
+    name: 'sanitizeAbstract'
+})
+export class SanitizeAbstractPipe implements PipeTransform {
+    transform(value: string, expectedSpaces?: number): string {
+        const maxSpaces = expectedSpaces || 20;
+        if(value.length < maxSpaces) { return value; }
+        let idx = value.indexOf(' ');
+        return ((idx < 0) || (idx > maxSpaces)) ? '(Looks jumbled)' : value;
+    }
+}

--- a/projects/storyline-viewer/src/lib/storyline-detail.component.css
+++ b/projects/storyline-viewer/src/lib/storyline-detail.component.css
@@ -1,0 +1,9 @@
+table {
+    width: 100%;
+}
+
+mat-cell, .mat-cell {
+  min-height: auto; 
+  padding: 12px 16px 12px 0;
+}
+

--- a/projects/storyline-viewer/src/lib/storyline-detail.component.html
+++ b/projects/storyline-viewer/src/lib/storyline-detail.component.html
@@ -1,0 +1,25 @@
+<div>
+<table *ngIf="detailDatasource" mat-table [dataSource]="detailDatasource" class="mat-elevation-z8">
+    <ng-container matColumnDef="title">
+      <th mat-header-cell *matHeaderCellDef> Title </th>
+      <td mat-cell *matCellDef="let element" [ngSwitch]="!!element.url" style="width:30%">
+        <span *ngSwitchCase="true"><a [href]="element.url" target="_blank">{{ element.title | titlecase }}</a></span>
+        <span *ngSwitchCase="false">{{ element.title | titlecase }}</span>
+      </td>
+    </ng-container>
+
+    <ng-container matColumnDef="date">
+      <th mat-header-cell *matHeaderCellDef> Published </th>
+      <td mat-cell *matCellDef="let element" style="width: 10%">{{ element.date | date }}</td>
+    </ng-container>
+
+    <ng-container matColumnDef="desc">
+      <th mat-header-cell *matHeaderCellDef> Description </th>
+      <td mat-cell *matCellDef="let element">{{ element.doc_abstract | sanitizeAbstract }}</td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="displayedStorylineColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedStorylineColumns;"></tr>
+  </table>
+  <mat-paginator style="width:100%" #paginator [pageSizeOptions]="[10, 20, 50]" showFirstLastButtons></mat-paginator>
+</div>

--- a/projects/storyline-viewer/src/lib/storyline-detail.component.ts
+++ b/projects/storyline-viewer/src/lib/storyline-detail.component.ts
@@ -1,0 +1,39 @@
+import { AfterViewInit, Component, Input, ViewChild } from '@angular/core';
+import { Article, View } from './types';
+import { MatTableDataSource } from '@angular/material/table';
+import { MatPaginator } from '@angular/material/paginator';
+import { filterArticles } from './types';
+import * as _ from 'lodash';
+
+@Component({
+    selector: 'ngx-storyline-detail',
+    templateUrl: './storyline-detail.component.html',
+    styleUrls: ['./storyline-detail.component.css']
+})
+export class StorylineDetailComponent implements AfterViewInit {
+
+    displayedStorylineColumns: string[] = ['title', 'date', 'desc'];
+    detailDatasource: MatTableDataSource<Article>;
+    @Input() articles: Article[];
+    @ViewChild(MatPaginator) paginator: MatPaginator;
+
+    _view: View;
+
+    @Input()
+    set filter(x: View) {
+        this._view = x;
+        this.applyCurrentFilter();
+    }
+
+    applyCurrentFilter() {
+        this.detailDatasource = new MatTableDataSource<Article>(_.isNil(this._view) ? this.articles : filterArticles(this.articles, this._view));
+        if(this.paginator) {
+            this.paginator.pageIndex = 0;
+            this.detailDatasource.paginator = this.paginator;
+        }
+    }
+
+    ngAfterViewInit() {
+        this.applyCurrentFilter();
+    }
+}

--- a/projects/storyline-viewer/src/lib/storyline-viewer.component.css
+++ b/projects/storyline-viewer/src/lib/storyline-viewer.component.css
@@ -1,48 +1,25 @@
 
-
-#filters {
-  height: 130px;
-  display: flex;
-  margin-bottom: 30px;
-}
-
-.filter-title {
-  margin-left: 15px;
-}
-
-.filter {
-  padding: 5px;
-  height: 100px;
-  border: 1px solid black;
-  overflow-y: scroll;
-}
-
 table {
   width: 100%;
+}
+
+tr.detail-row {
+  height: 0;
+}
+
+tr.storyline-row:not(.expanded-row):hover {
+  background: #f5f5f5;
+}
+
+tr.storyline-row:not(.expanded-row):active {
+  background: #efefef;
+}
+
+.storyline-row td {
+  border-bottom-width: 0;
 }
 
 .storylines-table-list {
   margin-left: 0px;
   padding-left: 0px;
-}
-
-#views {
-  display: flex;
-  margin-bottom: 15px;
-}
-
-#views > div {
-  border: 1px solid black;
-}
-
-.view-selected {
-  color: white;
-  background-color: black;
-}
-
-#storyline-articles {
-  position: fixed;
-  top: 0vw;
-  height: 100vw;
-  background: white;
 }

--- a/projects/storyline-viewer/src/lib/storyline-viewer.component.html
+++ b/projects/storyline-viewer/src/lib/storyline-viewer.component.html
@@ -1,64 +1,95 @@
-<div
-  #storylines
-  id="storylines"
-  style="display: block"
->
+<div *ngIf="_loadingStorylines || !_componentsLoaded">
+  <mat-progress-bar mode="query"></mat-progress-bar>
+</div>
 
-  <div #viewsElem id="views">
-    <div (click)="selectView($event, 'all')" class='view-selected'>All Storylines</div>
-    <div
-      *ngFor="let item of views | keyvalue"
-      (click)="selectView($event, item.key)"
-      class="{{ currentView === item.key ? 'view-selected': ''}}"
-    >
-      {{ item.key }}
-    </div>
-    <div id='views-plus' (click)="addView()">+</div>
-  </div>
+<div [style]="'display: ' + ((_hasFirstStorylines && _componentsLoaded) ? 'block;' : 'none;')">
 
-  <div #filtersElem id='filters' style='display: none;'>
-    <div class='filter-box' *ngFor="let filter of getObjectKeys(filters)">
-      <div class='filter-title'>
-        <span style="font-weight: bold; text-transform: capitalize;">{{ filter }}</span> ({{ filters[filter].size }}) <a href='#' (click)="selectAll(filter)">(Select All)</a>
-      </div>
-      <div class='filter'>
-        <div *ngFor="let element of sortSet(filters[filter])">
-          <input
-            type='checkbox'
-            id='checkbox-{{ filter }}-{{element}}'
-            [checked]="currentView !== 'all' && views[currentView][filter].has(element)"
-            (change)="applyFilter($event, filter, element)"
-          />
-          <label for='checkbox-{{ filter }}-{{element}}'>{{ element }}</label>
-        </div>
-      </div>
+<!--
+   We will use the tab group just for navigation because it is inefficient to have multiple tables for each view.
+   It makes more sense to have a single table and switch the filter function according to the view.
+-->
+<mat-tab-group #storyViews (selectedIndexChange)="onSelectView($event)">
+  <mat-tab [label]="_LABEL_ALL_STORYLINES" selected>
+  </mat-tab>
+  <mat-tab *ngFor="let item of views | keyvalue" [label]="item.key">
+  </mat-tab>
+  <mat-tab>
+    <ng-template mat-tab-label>
+      <mat-icon>add_circle</mat-icon>
+    </ng-template>
+  </mat-tab>
+</mat-tab-group>
+<br/>
+<mat-card *ngIf="currentView != 'all'">
+  <mat-card-header>This view filters for:</mat-card-header>
+  <mat-card-content>
+    <ul>
+        <li *ngFor="let filter of getObjectKeys(filters)">
+          {{filter | titlecase}}: <span *ngIf="!currentViewHasFilter(filter)">None</span>
+          {{ currentViewFilterDescription(filter) }}
+        </li>
+    </ul>    
+  </mat-card-content>
+  <mat-card-actions>
+    <button mat-stroked-button color="primary" (click)="renameView()">Rename</button>&nbsp;
+    <button mat-stroked-button color="warn" (click)="deleteView()">Delete</button>
+  </mat-card-actions>
+</mat-card>
+<br/>
+<!-- this is our filter list -->
+<mat-grid-list [style]="'display: ' + (_allSelected ? 'none;' : 'block;')" [cols]="getObjectKeys(filters).length" [rowHeight]="350">
+  <mat-grid-tile *ngFor="let filter of getObjectKeys(filters)">
+    <mat-grid-tile-header>{{ filter | titlecase }} ({{filters[filter].size}})</mat-grid-tile-header>
+    <div>
+      <br/>
+      <br/>
+      <mat-selection-list 
+          style="height:280px; overflow: auto" 
+          (selectionChange)="onChangeSelection(filter, $event)"
+          infiniteScroll
+          [infiniteScrollThrottle]="50"
+          [infiniteScrollDisabled]="this.filterOptions[filter].offset >= this.filterOptions[filter].total"
+          [scrollWindow]="false"
+          (scrolled)="getNextBatch(filter)"
+      >
+        <mat-list-option 
+          *ngFor="let element of this.filterOptions[filter].pipeline$ | async" 
+          [value]="element"
+          [selected]="(currentView != 'all') && views[currentView][filter].has(element)">
+          {{element | titlecase}}
+        </mat-list-option>
+      </mat-selection-list>
     </div>
-  </div>
+  </mat-grid-tile>
+  
+</mat-grid-list>
 
   <table
     mat-table
     [dataSource]="storylinesDataSource"
-    class="mat-elevation-z8 storylines-table"
+    class="mat-elevation-z8"
+    multiTemplateDataRows
     infiniteScroll
-      [infiniteScrollDistance]="1"
-      [infiniteScrollThrottle]="50"
-      (scrolled)="onScroll()"
-  >
+    [infiniteScrollDistance]="1"
+    [infiniteScrollThrottle]="50"
+    (scrolled)="onScroll()">
+
     <ng-container matColumnDef="count">
-      <th mat-header-cell *matHeaderCellDef> Count </th>
+      <th mat-header-cell *matHeaderCellDef> Stories </th>
       <td mat-cell *matCellDef="let element">
-        {{ element.articles.length }}<br />
-        <a href="#" (click)="openStoryline(element.position)">Open</a>
+        {{ getFilteredArticleCount(element) }} articles<br/>
+        {{element.update | date}}
       </td>
     </ng-container>
 
     <ng-container matColumnDef="concepts">
-      <th mat-header-cell *matHeaderCellDef> Concepts </th>
+      <th mat-header-cell *matHeaderCellDef> Entities </th>
       <td mat-cell *matCellDef="let element">
         <ul class='storylines-table-list'>
-          <li *ngFor="let concept of element.concepts.slice(0, 5)">
+          <li *ngFor="let concept of element.concepts.slice(0, 5)" >
             {{concept}}
           </li>
+          <li *ngIf="element.concepts.length > 5" [matTooltip]="element.concepts | remainingConcepts">More...</li>
         </ul>
       </td>
     </ng-container>
@@ -68,7 +99,10 @@
       <td mat-cell *matCellDef="let element">
         <mat-chip-list>
           <mat-chip *ngFor="let driver of element.drivers.slice(0, 5)" (click)="driverSelect(driver)">
-            {{ driver }}
+            {{ driver | titlecase }}
+          </mat-chip>
+          <mat-chip *ngIf="element.drivers.length > 5" (click)="showMore(element.drivers.slice(5))">
+            <mat-icon>more_horiz</mat-icon>
           </mat-chip>
         </mat-chip-list>
       </td>
@@ -85,33 +119,23 @@
       </td>
     </ng-container>
 
-    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-    <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-  </table>
-</div>
-
-
-<div
-  #storylineArticles
-  id="storyline-articles"
-  style="display: none"
->
-  <a (click)="closeStoryline()">Close</a><br /><br />
-  <table mat-table [dataSource]="articles" class="mat-elevation-z8">
-    <ng-container matColumnDef="title">
-      <th mat-header-cell *matHeaderCellDef> Title </th>
-      <td mat-cell *matCellDef="let element" [ngSwitch]="!!element.url">
-        <span *ngSwitchCase="true"><a href="{{ element.url }}" target="_blank">{{ element.title }}</a></span>
-        <span *ngSwitchCase="false">{{ element.title }}</span>
+    <ng-container matColumnDef='expandedDetail'>
+      <td mat-cell *matCellDef="let storyline; let i = dataIndex" [attr.colspan]="displayedColumns.length">
+        <div [@detailExpand]="storyline == expandedElement ? 'expanded': 'collapsed'" style="width: 100%">
+          <ngx-storyline-detail [articles]="storyline.articles" [filter]="(this.currentView === 'all') ? null : this.views[this.currentView]">
+          </ngx-storyline-detail>
+        </div>
       </td>
     </ng-container>
 
-    <ng-container matColumnDef="desc">
-      <th mat-header-cell *matHeaderCellDef> Description </th>
-      <td mat-cell *matCellDef="let element">{{ element.doc_abstract }}</td>
-    </ng-container>
-
-    <tr mat-header-row *matHeaderRowDef="displayedStorylineColumns"></tr>
-    <tr mat-row *matRowDef="let row; columns: displayedStorylineColumns;"></tr>
+    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr mat-row 
+      *matRowDef="let row; columns: displayedColumns;let i = dataIndex"
+      class="storyline-row"
+      [class.expanded-row]="expandedElement === row"
+      (click)="setExpandedElement(row, i)">
+    ></tr>
+    <tr mat-row *matRowDef="let row; columns: ['expandedDetail']" class="detail-row"></tr>
   </table>
+
 </div>

--- a/projects/storyline-viewer/src/lib/storyline-viewer.component.ts
+++ b/projects/storyline-viewer/src/lib/storyline-viewer.component.ts
@@ -1,54 +1,162 @@
-import { Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output, ViewChild, AfterViewInit, ViewChildren, QueryList } from '@angular/core';
 import { MatTable, MatTableDataSource } from '@angular/material/table';
 import { StorylineViewerService } from './storyline-viewer.service';
-import { Storyline, Article, StorylineTableElement, View } from './types';
+import { Storyline, Article, StorylineTableElement, View, filterArticleCount } from './types';
+import { MatTabGroup} from '@angular/material/tabs';
+import { MatSelectionListChange } from '@angular/material/list';
+import { animate, state, style, transition, trigger } from '@angular/animations';
+import { MatPaginator } from '@angular/material/paginator';
+import { MatBottomSheet } from '@angular/material/bottom-sheet';
+import { DriversSheet } from './drivers-sheet.component';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { scan } from 'rxjs/operators';
+
+export interface FilterScrollStatus {
+    offset: number;
+    total: number;
+    subject: BehaviorSubject<string[]>;
+    pipeline$: Observable<string[]>;
+    basis: string[];
+}
 
 @Component({
   selector: 'ngx-storyline-viewer',
   templateUrl: './storyline-viewer.component.html',
   styleUrls: ['./storyline-viewer.component.css'],
+  animations: [
+    trigger('detailExpand', [
+      state('collapsed', style({height: '0px', minHeight: '0', display: 'none'})),
+      state('expanded', style({height: '*'})),
+      transition('expanded <=> collapsed', animate('225ms cubic-bezier(0.4, 0.0, 0.2, 1)')),
+    ]),
+  ],
 })
-export class StorylineViewerComponent implements OnInit {
+export class StorylineViewerComponent implements OnInit, AfterViewInit {
+
+  _LABEL_ALL_STORYLINES = "All storylines";
+  _BATCH_SIZE = 100;
+  /** Array of view keys to ensure the same order of keys. */
+  _viewKeys: string[] = [];
+  _hasFirstStorylines = false;
+  _loadingStorylines = false;
+  _allSelected = true;
+  _componentsLoaded = false;
+  expandedElement: StorylineTableElement;
+  expandedDataSource: MatTableDataSource<Article>;
+  
   displayedColumns: string[] = ['count', 'concepts', 'drivers', 'articles'];
 
   filters: View = {
     people: new Set<string>(),
     companies: new Set<string>(),
-    organizations: new Set<string>()
+    organizations: new Set<string>(),
+    categories: new Set<string>()
   };
 
+  filterOptions: {[key: string]: FilterScrollStatus};
+
   storylines: StorylineTableElement[] = [];
+  @ViewChild('storyViews') storyViews: MatTabGroup;
   @ViewChild('storylinesTable') storylinesTable: MatTable<StorylineTableElement>;
-  @ViewChild('storylines') storylinesElem: ElementRef;
+  @ViewChildren(MatPaginator) paginators: QueryList<MatPaginator>;
 
   storylinesDataSource = new MatTableDataSource();
 
-  displayedStorylineColumns: string[] = ['title', 'desc'];
   articles: Article[] = [];
-  @ViewChild('storylineArticles') storylineArticlesElem: ElementRef;
-
-  @ViewChild('viewsElem') viewElem: ElementRef;
-  @ViewChild('filtersElem') filtersElem: ElementRef;
 
   @Input() serviceUrl: string;
-
   @Input() count = 10;
-
   @Input() currentView = 'all';
   @Input() views: {[key: string]: View} = {};
 
   @Output() viewEvent: EventEmitter<{currentView: string, views: {[key: string]: View}}> = new EventEmitter();
   @Output() driverEvent: EventEmitter<string> = new EventEmitter();
 
-  constructor(
-    private storylineViewerService: StorylineViewerService,
-    private element: ElementRef
-  ) {
+  constructor(private storylineViewerService: StorylineViewerService, private _bottomSheet: MatBottomSheet) {
+  }
+
+  onSelectView(evidx: number) {
+    this.expandedElement = undefined;
+    if(evidx === 0) {
+      // this is the 'all storylines view'
+      this._allSelected = true;
+      this.currentView = 'all';
+      this.storylinesDataSource.filter = '';
+    } else if(evidx == (this.storyViews._allTabs.length - 1)) {
+      this._allSelected = false;
+      // this is the 'add view'
+      this.addView();
+      // set a timeout to flip to this view from the add
+      setTimeout(() => { this.storyViews.selectedIndex = this.storyViews._allTabs.length - 2; }, 1000)
+    } else {
+      // this is a custom view
+      this._allSelected = false;
+      const label = this.storyViews._allTabs.toArray()[evidx].textLabel;
+      this.currentView = label;
+      this.storylinesDataSource.filter = JSON.stringify(this.views[this.currentView] || {});
+    }
+    this.dispatchViewEvent();
+  }
+
+  onChangeSelection(filter: string, event: MatSelectionListChange) {
+    if (event.option.selected) {
+      this.views[this.currentView][filter].add(event.option.value);
+    }
+    else {
+      this.views[this.currentView][filter].delete(event.option.value);
+    }
+    this.storylinesDataSource.filter = JSON.stringify(this.views[this.currentView]);
+    this.dispatchViewEvent();    
+  }
+
+  initializeOrUpdateFilterOptions() {
+    if(!this.filterOptions) { this.filterOptions = {}; }
+    for(const k in this.filters) {
+      const crset = this.sortSet(this.filters[k]);
+      const bsubj = new BehaviorSubject<string[]>([]); 
+      if(!(k in this.filterOptions) || ((k in this.filterOptions) && (this.filterOptions[k].total != crset.length))) {
+        this.filterOptions[k] = {
+          offset: 0,
+          total: crset.length,
+          basis: crset,
+          subject: bsubj,
+          pipeline$: bsubj.asObservable().pipe(scan((acc, curr) => [...acc, ...curr], []))
+        };
+        this.getNextBatch(k);
+      }
+    }
+  }
+
+  resetFilterOptions(filter: string) {
+    const crset = this.sortSet(this.filters[filter]);
+    const bsubj = new BehaviorSubject<string[]>([]); 
+    this.filterOptions[filter] = {
+      offset: 0,
+      total: crset.length,
+      basis: crset,
+      subject: bsubj,
+      pipeline$: bsubj.asObservable().pipe(scan((acc, curr) => [...acc, ...curr], []))
+    };
+    this.getNextBatch(filter);
+  }
+
+  resetAllFilters() {
+    this.filterOptions = undefined;
+    this.initializeOrUpdateFilterOptions();
+  }
+
+  getNextBatch(filter) {
+    if(!(filter in this.filterOptions)) { return; }
+    const batchSize = Math.min(this._BATCH_SIZE, this.filterOptions[filter].total - this.filterOptions[filter].offset);
+    const results = this.filterOptions[filter].basis.slice(this.filterOptions[filter].offset, this.filterOptions[filter].offset + batchSize);
+    this.filterOptions[filter].subject.next(results);
+    this.filterOptions[filter].offset += batchSize;
   }
 
   ngOnInit() {
     this.storylineViewerService.url = this.serviceUrl;
     for (const key in this.views) {
+      this._viewKeys.push(key);
       for (const filter in this.filters) {
         if (Array.isArray(this.views[key][filter])) {
           this.views[key][filter] = new Set(this.views[key][filter]);
@@ -59,7 +167,7 @@ export class StorylineViewerComponent implements OnInit {
         this.filters[filter] = new Set([...this.filters[filter], ...this.views[key][filter]]);
       }
     }
-
+    this.resetAllFilters();
 
     this.storylinesDataSource.filterPredicate = ((data: StorylineTableElement, filter): boolean => {
       if (this.currentView === 'all') {
@@ -87,7 +195,13 @@ export class StorylineViewerComponent implements OnInit {
     this.getStorylines();
   }
 
+  ngAfterViewInit() {
+    this._componentsLoaded = true;
+    this.storyViews.selectedIndex = 0;
+  }
+
   getStorylines() {
+    this._loadingStorylines = true;
     this.storylineViewerService.getStorylines(
       this.storylines.length,
       this.count
@@ -95,9 +209,10 @@ export class StorylineViewerComponent implements OnInit {
       for (let storyline of storylines) {
         const concepts: {[key: string]: number} = {};
         const drivers: {[key: string]: number} = {};
+        let lastUpdate = new Date(1950, 1, 1);
         for (let article of storyline.articles) {
           for (let filter in this.filters) {
-            for (let concept of article[filter === 'people' ? 'persons' : filter]) {
+            for (let concept of article[(filter === 'people') ? 'persons' : filter]) {
               if (!concepts[concept.name]) {
                 concepts[concept.name] = 0;
               }
@@ -111,19 +226,29 @@ export class StorylineViewerComponent implements OnInit {
             }
             drivers[driver]++;
           }
+          const crdate = new Date(article.date);
+          if(lastUpdate.getTime() < crdate.getTime()) {
+            lastUpdate = crdate;
+          }
         }
+
+        this.initializeOrUpdateFilterOptions();
 
         this.storylines.push({
           position: this.storylines.length,
           articles: storyline.articles,
           concepts: this.flattenObjectCount(concepts),
-          drivers: this.flattenObjectCount(drivers)
+          drivers: this.flattenObjectCount(drivers),
+          update: lastUpdate
         });
       }
       this.storylinesDataSource.data = this.storylines;
       if (this.storylinesTable) {
         this.storylinesTable.renderRows();
       }
+
+      this._hasFirstStorylines = true;
+      this._loadingStorylines = false;
     });
   }
 
@@ -145,22 +270,6 @@ export class StorylineViewerComponent implements OnInit {
     this.getStorylines();
   }
 
-  openStoryline(position: number) {
-    this.storylineViewerService.getStoryline(position).subscribe((storyline: Storyline) => {
-      this.articles = storyline.articles;
-      //this.storylinesElem.nativeElement.style.display = 'none';
-      this.storylineArticlesElem.nativeElement.style.display = 'block';
-      //this.storylinesElem.nativeElement.style.overflowY = 'hidden';
-    });
-  }
-
-  closeStoryline() {
-    this.articles = [];
-    //this.storylinesElem.nativeElement.style.display = 'block';
-    //this.storylinesElem.nativeElement.style.overflowY = '';
-    this.storylineArticlesElem.nativeElement.style.display = 'none';
-  }
-
   sortSet(set: Set<string>) {
     return Array.from(set).sort();
   }
@@ -169,40 +278,28 @@ export class StorylineViewerComponent implements OnInit {
     return Object.keys(obj);
   }
 
-  applyFilter(event: InputEvent, type: string, value: string) {
-    if ((event.target as HTMLInputElement).checked) {
-      this.views[this.currentView][type].add(value);
-    }
-    else {
-      this.views[this.currentView][type].delete(value);
-    }
-    this.storylinesDataSource.filter = JSON.stringify(this.views[this.currentView]);
-    this.dispatchViewEvent();
-  }
-
   addView() {
-    const viewName = `View ${this.viewElem.nativeElement.children.length - 1}`;
+    let found = false;
+    let idx = 1;
+    while(!found) {
+      if(!(('View ' + idx) in this.views)) { found = true; }
+      else { idx++; }
+    }
+    const viewName = 'View ' + idx;
     this.currentView = viewName;
     this.views[viewName] = {
       people: new Set(),
       companies: new Set(),
-      organizations: new Set()
+      organizations: new Set(),
+      categories: new Set()
     };
-    this.selectView(null, this.currentView);
     this.dispatchViewEvent();
   }
 
-  selectView(event: MouseEvent | null, view: string) {
-    this.currentView = view;
-    this.filtersElem.nativeElement.style.display = (this.currentView !== 'all') ? 'flex' : 'none';
-    this.storylinesDataSource.filter = JSON.stringify(this.views[this.currentView] || {});
-    if (document.querySelector('.view-selected')) {
-      document.querySelector('.view-selected').classList.remove('view-selected');
-    }
-    if (event) {
-      (event.target as Element).classList.add('view-selected');
-      this.dispatchViewEvent();
-    }
+  setExpandedElement(elem: StorylineTableElement, idx: number) {
+    if(this.expandedElement === elem) {
+      this.expandedElement = undefined;
+    } else { this.expandedElement = elem; }
   }
 
   dispatchViewEvent() {
@@ -222,5 +319,53 @@ export class StorylineViewerComponent implements OnInit {
 
   driverSelect(driver: string) {
     this.driverEvent.emit(driver);
+  }
+
+  getFilteredArticleCount(data: StorylineTableElement) {
+    return (this.currentView === 'all') ? data.articles.length : filterArticleCount(data, this.views[this.currentView]);
+  }
+
+  showMore(drivers) {
+    const bsref = this._bottomSheet.open(DriversSheet, {data: drivers});
+    const devent = this.driverEvent;
+    bsref.afterDismissed().subscribe(result => {
+      if(result) {
+        devent.emit(result);
+      }
+    });
+  }
+
+  renameView() {
+    const ret = window.prompt('What would you like to call this view?', this.currentView);
+    if(ret) {
+      this.views[ret] = this.views[this.currentView];
+      delete this.views[this.currentView];
+      const idx = this._viewKeys.indexOf(this.currentView);
+      if(idx >= 0) {
+        this._viewKeys.splice(idx, 1, ret);
+      }
+      this.currentView = ret;
+    }
+  }
+
+  deleteView() {
+    if(window.confirm('Are you certain you want to delete this view? This operation cannot be undone.')) {
+      // delete current view
+      delete this.views[this.currentView];
+      this.currentView = 'all';
+      this.storyViews.selectedIndex = 0;
+    }
+  }
+
+  currentViewHasFilter(filter: string): boolean {
+    if(this.views[this.currentView]) {
+      return Array.from(this.views[this.currentView][filter]).length > 0;
+    } else { return false; }
+  }
+
+  currentViewFilterDescription(filter: string): string {
+    if(this.views[this.currentView]) {
+      return Array.from(this.views[this.currentView][filter]).join(', ');
+    } else { return ''; }
   }
 }

--- a/projects/storyline-viewer/src/lib/storyline-viewer.module.ts
+++ b/projects/storyline-viewer/src/lib/storyline-viewer.module.ts
@@ -5,19 +5,53 @@ import { StorylineViewerComponent } from './storyline-viewer.component';
 
 
 import { MatTableModule } from '@angular/material/table';
+import { MatTabsModule } from '@angular/material/tabs';
+import { MatIconModule } from '@angular/material/icon';
 import { MatChipsModule } from '@angular/material/chips';
+import { MatGridListModule } from '@angular/material/grid-list';
+import { MatListModule } from '@angular/material/list';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { MatPaginatorModule } from '@angular/material/paginator';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatBottomSheetModule } from '@angular/material/bottom-sheet';
+import { MatCardModule } from '@angular/material/card';
+import { MatButtonModule } from '@angular/material/button';
 import { InfiniteScrollModule } from 'ngx-infinite-scroll';
 import { StorylineViewerService } from './storyline-viewer.service';
+import { StorylineDetailComponent } from './storyline-detail.component';
+import { SanitizeAbstractPipe } from './sanitize-abstract.pipe';
+import { RemainingConceptsPipe } from './remaining-concepts.pipe';
+import { DriversSheet } from './drivers-sheet.component';
 
 @NgModule({
   declarations: [
-    StorylineViewerComponent
+    SanitizeAbstractPipe,
+    RemainingConceptsPipe,
+    DriversSheet,
+    StorylineViewerComponent,
+    StorylineDetailComponent
   ],
   imports: [
     CommonModule,
     HttpClientModule,
     MatTableModule,
+    MatTabsModule,
+    MatIconModule,
     MatChipsModule,
+    MatGridListModule,
+    MatListModule,
+    MatDividerModule,
+    MatProgressBarModule,
+    MatPaginatorModule,
+    MatTooltipModule,
+    MatBottomSheetModule,
+    MatCardModule,
+    MatButtonModule,
+    BrowserModule,
+    BrowserAnimationsModule,
     InfiniteScrollModule
   ],
   exports: [
@@ -25,6 +59,7 @@ import { StorylineViewerService } from './storyline-viewer.service';
   ],
   providers: [
     StorylineViewerService
-  ]
+  ],
+  entryComponents: [ DriversSheet ]
 })
 export class StorylineViewerModule { }

--- a/projects/storyline-viewer/src/lib/types.ts
+++ b/projects/storyline-viewer/src/lib/types.ts
@@ -1,7 +1,9 @@
+import * as _ from 'lodash';
+
 export interface Entity {
   name: string;
   relevance: number;
-  sentiment: number;
+  sentiment?: number;
   count: number;
 }
 
@@ -13,7 +15,7 @@ export interface Article {
   date: string;
   url: string;
   country?: string;
-  categories: {[key: string]: any};
+  categories: Entity[];
   persons: Entity[];
   companies: Entity[];
   organizations: Entity[];
@@ -37,11 +39,45 @@ export interface StorylineTableElement {
   position: number;
   articles: Article[],
   concepts: string[],
-  drivers: string[]
+  drivers: string[],
+  update: Date
 }
 
 export interface View {
   people: Set<string>;
   companies: Set<string>;
   organizations: Set<string>;
+  categories: Set<string>;
+}
+
+export function filterArticles(articles: Article[], view: View): Article[] {
+  const retval = [];  
+  let done;
+  for(const a of articles) {
+    done = false;
+    for(const k of _.keys(view)) {
+      const datak = getDataKeyFromViewKey(k);
+      for(const v of view[k]) {
+        if(_.some(a[datak], elem => elem.name === v)) {
+          done = true;
+          retval.push(a);
+          break;
+        }
+      }
+      if(done) { break; }
+    }
+  }
+  return retval;
+}
+
+export function filterStorylineArticles(data: StorylineTableElement, view: View): Article[] {
+  return filterArticles(data.articles, view);
+}
+
+export function filterArticleCount(data: StorylineTableElement, view: View): number {
+  return filterArticles(data.articles, view).length;
+}
+
+export function getDataKeyFromViewKey(key: string): string {
+  return (key === 'people') ? 'persons' : key;
 }


### PR DESCRIPTION
Signed-off-by: Octavian Udrea <udrea@us.ibm.com>
Author: Octavian Udrea <udrea@us.ibm.com>

- Add material styling to views and filters
- Renamed 'concepts' to 'entities'
- Remove view manipulation through element refs
- Updated data sample
- Changed storyline detail display to be an expansible row within the original storyline table
- Added 'See more' indicators to drivers and entities (entities are via a tooltip, drivers via a bottom sheet which allows selection)
- Added the last update time for a storyline to the first column and published time to each article
- Articles within a storyline (and their count) are now filtered according to the view filter criteria
- Added a sanitize pipe for abstracts (some contain jumbled html) - for abstracts detected not to contain a space within a certain number of characters, they are reduced to an empty string
- Added categories filter and populated categories in the sample data
- Added a description of a view to the top, as well as a delete (with confirmation) and a rename button
- Removed the Select all button for filters